### PR TITLE
Remove unused helper functions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,7 +183,6 @@ The tool supports optional git remote synchronization:
 - Rsync operations use specialized functions with retry logic:
   - `_juvy_rsync_with_includes()` for backup operations with pattern-based inclusion
   - `_juvy_rsync_restore()` for restore operations with bulk copying
-  - `_juvy_rsync_with_delete()` for legacy operations (deprecated)
 - Pattern generation uses helper functions `_juvy_add_directory_patterns()` and `_juvy_add_file_patterns()`
 - All rsync functions include comprehensive error handling and user-friendly messages
 - User prompts follow consistent emoji-based formatting for better UX

--- a/juvy/juvy.zsh
+++ b/juvy/juvy.zsh
@@ -144,11 +144,6 @@ _juvy_validate_backup_dir_configured() {
   return 0
 }
 
-_juvy_validate_remote_init() {
-  _juvy_validate_backup_dir_exists || return 1
-  return 0
-}
-
 _juvy_validate_time_format() {
   local time_value="$1"
   
@@ -175,22 +170,6 @@ _juvy_validate_schedule_frequency() {
       ;;
   esac
 }
-
-_juvy_validate_boolean() {
-  local value="$1"
-  
-  case "$value" in
-    (true|false)
-      return 0
-      ;;
-    (*)
-      print "❌ Invalid boolean value: $value" >&2
-      print "   Expected: true or false" >&2
-      return 1
-      ;;
-  esac
-}
-
 
 _juvy_parse_entry_basic() {
   local entry="$1"
@@ -1408,14 +1387,6 @@ _juvy_path_matches_pattern() {
       return $?
       ;;
   esac
-}
-
-_juvy_rsync_with_delete() {
-  local source="$1"
-  local dest="$2"
-  local files_from="$3"
-  
-  _juvy_rsync_simple -av --delete --files-from="$files_from" "$source" "$dest"
 }
 
 _juvy_rsync_with_includes() {


### PR DESCRIPTION
## Summary
- delete deprecated functions `_juvy_validate_remote_init`, `_juvy_validate_boolean`, and `_juvy_rsync_with_delete`
- clean up rsync section in `CLAUDE.md`

## Testing
- `zsh -n juvy/juvy.zsh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855585f8d448331b533290f34b6bf7d