### PR TITLE
Improve cross-platform date handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ juvy backup  # Create your first backup
 juvy list    # See what's being tracked
 ```
 
+## Compatibility
+
+juvy works on both GNU/Linux and macOS. If `gdate` from coreutils is
+available it will be used for date calculations; otherwise the
+platform's `date` command is used.
+
 ## Commands
 
 ### Setup and Configuration

--- a/juvy/juvy.zsh
+++ b/juvy/juvy.zsh
@@ -2314,16 +2314,27 @@ _juvy_show_file_diff() {
 }
 
 
+
 _juvy_get_relative_time() {
   local backup_date="$1"
-  local backup_epoch current_epoch diff_seconds
-  
-  if ! backup_epoch="$(date -d "$backup_date" +%s 2>/dev/null)"; then
+  local date_bin backup_epoch current_epoch diff_seconds
+
+  if command -v gdate >/dev/null 2>&1; then
+    date_bin="gdate"
+  else
+    date_bin="/bin/date"
+  fi
+
+  if ! backup_epoch="$("$date_bin" -d "$backup_date" +%s 2>/dev/null)"; then
+    backup_epoch="$("$date_bin" -j -f '%Y-%m-%d %H:%M:%S' "$backup_date" +%s 2>/dev/null)"
+  fi
+
+  if [[ -z "$backup_epoch" ]]; then
     echo "unknown time ago"
     return
   fi
-  
-  current_epoch="$(date +%s)"
+
+  current_epoch="$("$date_bin" +%s)"
   diff_seconds=$((current_epoch - backup_epoch))
   
   if (( diff_seconds < 60 )); then


### PR DESCRIPTION
## Summary
- support BSD `date` by falling back when `gdate` isn't available
- document Linux/macOS compatibility and optional `gdate`

## Testing
- `zsh -n juvy/juvy.zsh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68555866e3f48331957ff0ab279cd882