### PR TITLE
Managed zsh/bash shell injection for auto-backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ For `zsh` and `bash`, juvy installs a managed shell block that triggers `juvy ba
 If multiple shell sessions start at once, `juvy` uses a backup lock and skips overlapping runs to avoid rsync/git races.
 
 To disable automatic backups temporarily, set `JUVY_AUTO_BACKUP=0`.
-To throttle startup runs, set `JUVY_AUTO_BACKUP_INTERVAL=<seconds>` (default: `300`).
 To fully remove shell integration, run `juvy uninstall` or remove the managed juvy block from your shell rc file.
 
 ## Commands
@@ -88,7 +87,6 @@ Settings in `~/.config/juvy/config`:
 | `JUVY_REMOTE_AUTO_SYNC` | Auto-sync after backup when remote is configured | `true` |
 | `JUVY_REMOTE_NAME` | Git remote name | `origin` |
 | `JUVY_AUTO_BACKUP` | Enable shell-startup auto backup (`0` disables) | `1` |
-| `JUVY_AUTO_BACKUP_INTERVAL` | Minimum seconds between shell-startup auto backups | `300` |
 
 Example config:
 

--- a/README.md
+++ b/README.md
@@ -20,11 +20,13 @@ juvy init
 
 ## How It Works
 
-Every shell startup triggers `juvy backup` in the background. rsync only copies changed files, git only commits if there's something new. No scheduling, no daemons, no overhead.
+For `zsh` and `bash`, juvy installs a managed shell block that triggers `juvy backup` in the background for interactive shells. rsync only copies changed files, git only commits if there's something new. No scheduling, no daemons, no overhead.
 
 If multiple shell sessions start at once, `juvy` uses a backup lock and skips overlapping runs to avoid rsync/git races.
 
-To disable automatic backups, remove the `juvy backup` line from your shell rc file (`~/.zshrc` or `~/.bashrc`).
+To disable automatic backups temporarily, set `JUVY_AUTO_BACKUP=0`.
+To throttle startup runs, set `JUVY_AUTO_BACKUP_INTERVAL=<seconds>` (default: `300`).
+To fully remove shell integration, run `juvy uninstall` or remove the managed juvy block from your shell rc file.
 
 ## Commands
 
@@ -85,6 +87,8 @@ Settings in `~/.config/juvy/config`:
 | `JUVY_REMOTE_URL` | Git remote URL for syncing | (none) |
 | `JUVY_REMOTE_AUTO_SYNC` | Auto-sync after backup when remote is configured | `true` |
 | `JUVY_REMOTE_NAME` | Git remote name | `origin` |
+| `JUVY_AUTO_BACKUP` | Enable shell-startup auto backup (`0` disables) | `1` |
+| `JUVY_AUTO_BACKUP_INTERVAL` | Minimum seconds between shell-startup auto backups | `300` |
 
 Example config:
 

--- a/install.sh
+++ b/install.sh
@@ -54,30 +54,6 @@ remove_managed_block_from_file() {
   return 1
 }
 
-remove_legacy_integration_lines_from_file() {
-  local file_path="$1"
-  local temp_file
-
-  [[ -f "$file_path" ]] || return 0
-
-  temp_file="$file_path.tmp"
-  awk '
-    $0 == "# juvy dotfile backup tool" { next }
-    $0 == "export PATH=\"$HOME/.juvy:$PATH\"" { next }
-    $0 ~ /^[[:space:]]*\([[:space:]]*juvy backup >\/dev\/null 2>&1 &[[:space:]]*\)[[:space:]]*$/ { next }
-    $0 ~ /^[[:space:]]*juvy backup >\/dev\/null 2>&1 &[[:space:]]*$/ { next }
-    { print }
-  ' "$file_path" > "$temp_file"
-
-  if ! cmp -s "$file_path" "$temp_file" 2>/dev/null; then
-    mv "$temp_file" "$file_path"
-    return 0
-  fi
-
-  rm -f "$temp_file"
-  return 1
-}
-
 write_shell_integration_block() {
   local rc_file="$1"
 
@@ -141,7 +117,6 @@ upsert_shell_integration() {
   touch "$rc_file" 2>/dev/null || return 1
 
   remove_managed_block_from_file "$rc_file" "$JUVY_SHELL_INTEGRATION_START" "$JUVY_SHELL_INTEGRATION_END" >/dev/null 2>&1 || true
-  remove_legacy_integration_lines_from_file "$rc_file" >/dev/null 2>&1 || true
 
   if [[ -s "$rc_file" ]]; then
     printf '\n' >> "$rc_file"
@@ -150,7 +125,6 @@ upsert_shell_integration() {
   write_shell_integration_block "$rc_file"
 
   if [[ "$shell_name" == "bash" ]]; then
-    remove_legacy_integration_lines_from_file "$HOME/.bash_profile" >/dev/null 2>&1 || true
     ensure_bash_profile_bridge || return 1
   fi
 

--- a/install.sh
+++ b/install.sh
@@ -37,6 +37,8 @@ remove_managed_block_from_file() {
   local temp_file
 
   [[ -f "$file_path" ]] || return 0
+  grep -Fq "$start_marker" "$file_path" || return 1
+  grep -Fq "$end_marker" "$file_path" || return 1
 
   temp_file="$file_path.tmp"
   awk -v start="$start_marker" -v end="$end_marker" '
@@ -60,7 +62,7 @@ write_shell_integration_block() {
   cat >> "$rc_file" << EOF
 $JUVY_SHELL_INTEGRATION_START
 export PATH="\$HOME/.juvy:\$PATH"
-if [[ "\${JUVY_AUTO_BACKUP:-1}" != "0" ]] && [[ -o interactive ]] && command -v juvy >/dev/null 2>&1; then
+if [[ "\${JUVY_AUTO_BACKUP:-1}" != "0" ]] && [[ "\$-" == *i* ]] && command -v juvy >/dev/null 2>&1; then
   if [[ -z "\${JUVY_AUTO_BACKUP_STARTED:-}" ]]; then
     export JUVY_AUTO_BACKUP_STARTED=1
     juvy backup >/dev/null 2>&1 &

--- a/install.sh
+++ b/install.sh
@@ -6,27 +6,160 @@ set -e
 JUVY_DIR="$HOME/.juvy"
 JUVY_SCRIPT="$JUVY_DIR/juvy"
 JUVY_REPO_BASE="https://raw.githubusercontent.com/danecando/juvy/main"
+JUVY_SHELL_INTEGRATION_START="# >>> juvy auto backup >>>"
+JUVY_SHELL_INTEGRATION_END="# <<< juvy auto backup <<<"
 
-# Detect current shell for rc file
-detect_rc_file() {
+# Detect current shell name
+detect_shell_name() {
   local current_shell="${SHELL##*/}"
-  case "$current_shell" in
+  if [[ -n "$current_shell" ]]; then
+    echo "$current_shell"
+  else
+    echo "unknown"
+  fi
+}
+
+# Detect rc file for a given shell
+detect_rc_file() {
+  local shell_name="$1"
+
+  case "$shell_name" in
     zsh)  echo "$HOME/.zshrc" ;;
-    bash)
-      if [[ -f "$HOME/.bash_profile" ]]; then
-        echo "$HOME/.bash_profile"
-      else
-        echo "$HOME/.bashrc"
-      fi
-      ;;
+    bash) echo "$HOME/.bashrc" ;;
     *)    echo "$HOME/.profile" ;;
   esac
 }
 
+remove_managed_block_from_file() {
+  local file_path="$1"
+  local start_marker="$2"
+  local end_marker="$3"
+  local temp_file
+
+  [[ -f "$file_path" ]] || return 0
+
+  temp_file="$file_path.tmp"
+  awk -v start="$start_marker" -v end="$end_marker" '
+    $0 == start { in_block=1; next }
+    in_block && $0 == end { in_block=0; next }
+    !in_block { print }
+  ' "$file_path" > "$temp_file"
+
+  if ! cmp -s "$file_path" "$temp_file" 2>/dev/null; then
+    mv "$temp_file" "$file_path"
+    return 0
+  fi
+
+  rm -f "$temp_file"
+  return 1
+}
+
+remove_legacy_integration_lines_from_file() {
+  local file_path="$1"
+  local temp_file
+
+  [[ -f "$file_path" ]] || return 0
+
+  temp_file="$file_path.tmp"
+  awk '
+    $0 == "# juvy dotfile backup tool" { next }
+    $0 == "export PATH=\"$HOME/.juvy:$PATH\"" { next }
+    $0 ~ /^[[:space:]]*\([[:space:]]*juvy backup >\/dev\/null 2>&1 &[[:space:]]*\)[[:space:]]*$/ { next }
+    $0 ~ /^[[:space:]]*juvy backup >\/dev\/null 2>&1 &[[:space:]]*$/ { next }
+    { print }
+  ' "$file_path" > "$temp_file"
+
+  if ! cmp -s "$file_path" "$temp_file" 2>/dev/null; then
+    mv "$temp_file" "$file_path"
+    return 0
+  fi
+
+  rm -f "$temp_file"
+  return 1
+}
+
+write_shell_integration_block() {
+  local rc_file="$1"
+
+  cat >> "$rc_file" << EOF
+$JUVY_SHELL_INTEGRATION_START
+export PATH="\$HOME/.juvy:\$PATH"
+if [[ "\${JUVY_AUTO_BACKUP:-1}" != "0" ]] && [[ -o interactive ]] && command -v juvy >/dev/null 2>&1; then
+  if [[ -z "\${JUVY_AUTO_BACKUP_STARTED:-}" ]]; then
+    export JUVY_AUTO_BACKUP_STARTED=1
+    _juvy_auto_backup_interval="\${JUVY_AUTO_BACKUP_INTERVAL:-300}"
+    _juvy_auto_backup_stamp="\${XDG_STATE_HOME:-\$HOME/.local/state}/juvy/auto-backup.last"
+    if [[ "\$_juvy_auto_backup_interval" =~ ^[0-9]+$ ]] && (( _juvy_auto_backup_interval > 0 )); then
+      _juvy_auto_backup_now="\$(date +%s 2>/dev/null || echo 0)"
+      _juvy_auto_backup_prev=0
+      if [[ -f "\$_juvy_auto_backup_stamp" ]]; then
+        _juvy_auto_backup_prev="\$(cat "\$_juvy_auto_backup_stamp" 2>/dev/null || echo 0)"
+      fi
+      if (( _juvy_auto_backup_now - _juvy_auto_backup_prev >= _juvy_auto_backup_interval )); then
+        mkdir -p "\$(dirname "\$_juvy_auto_backup_stamp")" >/dev/null 2>&1
+        echo "\$_juvy_auto_backup_now" > "\$_juvy_auto_backup_stamp" 2>/dev/null
+        juvy backup >/dev/null 2>&1 &
+      fi
+    else
+      juvy backup >/dev/null 2>&1 &
+    fi
+    unset _juvy_auto_backup_interval _juvy_auto_backup_stamp _juvy_auto_backup_now _juvy_auto_backup_prev
+  fi
+fi
+$JUVY_SHELL_INTEGRATION_END
+EOF
+}
+
+ensure_bash_profile_bridge() {
+  local bash_profile="$HOME/.bash_profile"
+  local bridge_start="# >>> juvy bashrc bridge >>>"
+  local bridge_end="# <<< juvy bashrc bridge <<<"
+
+  touch "$bash_profile" 2>/dev/null || return 1
+  remove_managed_block_from_file "$bash_profile" "$bridge_start" "$bridge_end" >/dev/null 2>&1 || true
+
+  if [[ -s "$bash_profile" ]]; then
+    printf '\n' >> "$bash_profile"
+  fi
+
+  cat >> "$bash_profile" << 'EOF'
+# >>> juvy bashrc bridge >>>
+if [ -f "$HOME/.bashrc" ]; then
+  . "$HOME/.bashrc"
+fi
+# <<< juvy bashrc bridge <<<
+EOF
+
+  return 0
+}
+
+upsert_shell_integration() {
+  local shell_name="$1"
+  local rc_file
+
+  rc_file="$(detect_rc_file "$shell_name")"
+  touch "$rc_file" 2>/dev/null || return 1
+
+  remove_managed_block_from_file "$rc_file" "$JUVY_SHELL_INTEGRATION_START" "$JUVY_SHELL_INTEGRATION_END" >/dev/null 2>&1 || true
+  remove_legacy_integration_lines_from_file "$rc_file" >/dev/null 2>&1 || true
+
+  if [[ -s "$rc_file" ]]; then
+    printf '\n' >> "$rc_file"
+  fi
+
+  write_shell_integration_block "$rc_file"
+
+  if [[ "$shell_name" == "bash" ]]; then
+    remove_legacy_integration_lines_from_file "$HOME/.bash_profile" >/dev/null 2>&1 || true
+    ensure_bash_profile_bridge || return 1
+  fi
+
+  return 0
+}
+
 # Check prerequisites
-current_shell="${SHELL##*/}"
-if [[ "$current_shell" != "bash" && "$current_shell" != "zsh" ]]; then
-  echo "juvy requires bash or zsh" >&2
+if ! command -v bash >/dev/null 2>&1; then
+  echo "juvy requires bash" >&2
   exit 1
 fi
 
@@ -55,15 +188,21 @@ fi
 
 chmod +x "$JUVY_SCRIPT"
 
-# Add to PATH in rc file if not already there
-RC_FILE="$(detect_rc_file)"
-if ! grep -q '\.juvy' "$RC_FILE" 2>/dev/null; then
-  {
-    echo ""
-    echo "# juvy dotfile backup tool"
-    echo 'export PATH="$HOME/.juvy:$PATH"'
-    echo '( juvy backup >/dev/null 2>&1 & )'
-  } >> "$RC_FILE"
+# Configure shell integration
+current_shell="$(detect_shell_name)"
+target_shell="$current_shell"
+if [[ "$target_shell" != "zsh" && "$target_shell" != "bash" ]]; then
+  if [[ -f "$HOME/.zshrc" ]]; then
+    target_shell="zsh"
+  else
+    target_shell="bash"
+  fi
+  echo "Detected shell '$current_shell'. Configuring $target_shell integration."
+fi
+
+if ! upsert_shell_integration "$target_shell"; then
+  echo "Failed to configure shell integration for $target_shell" >&2
+  exit 1
 fi
 
 # Add to current PATH for immediate use

--- a/install.sh
+++ b/install.sh
@@ -63,23 +63,7 @@ export PATH="\$HOME/.juvy:\$PATH"
 if [[ "\${JUVY_AUTO_BACKUP:-1}" != "0" ]] && [[ -o interactive ]] && command -v juvy >/dev/null 2>&1; then
   if [[ -z "\${JUVY_AUTO_BACKUP_STARTED:-}" ]]; then
     export JUVY_AUTO_BACKUP_STARTED=1
-    _juvy_auto_backup_interval="\${JUVY_AUTO_BACKUP_INTERVAL:-300}"
-    _juvy_auto_backup_stamp="\${XDG_STATE_HOME:-\$HOME/.local/state}/juvy/auto-backup.last"
-    if [[ "\$_juvy_auto_backup_interval" =~ ^[0-9]+$ ]] && (( _juvy_auto_backup_interval > 0 )); then
-      _juvy_auto_backup_now="\$(date +%s 2>/dev/null || echo 0)"
-      _juvy_auto_backup_prev=0
-      if [[ -f "\$_juvy_auto_backup_stamp" ]]; then
-        _juvy_auto_backup_prev="\$(cat "\$_juvy_auto_backup_stamp" 2>/dev/null || echo 0)"
-      fi
-      if (( _juvy_auto_backup_now - _juvy_auto_backup_prev >= _juvy_auto_backup_interval )); then
-        mkdir -p "\$(dirname "\$_juvy_auto_backup_stamp")" >/dev/null 2>&1
-        echo "\$_juvy_auto_backup_now" > "\$_juvy_auto_backup_stamp" 2>/dev/null
-        juvy backup >/dev/null 2>&1 &
-      fi
-    else
-      juvy backup >/dev/null 2>&1 &
-    fi
-    unset _juvy_auto_backup_interval _juvy_auto_backup_stamp _juvy_auto_backup_now _juvy_auto_backup_prev
+    juvy backup >/dev/null 2>&1 &
   fi
 fi
 $JUVY_SHELL_INTEGRATION_END

--- a/juvy.sh
+++ b/juvy.sh
@@ -1950,6 +1950,8 @@ _juvy_remove_managed_block_from_file() {
   local temp_file
 
   [[ -f "$file_path" ]] || return 0
+  grep -Fq "$start_marker" "$file_path" || return 1
+  grep -Fq "$end_marker" "$file_path" || return 1
 
   temp_file="$file_path.tmp"
   awk -v start="$start_marker" -v end="$end_marker" '
@@ -1973,7 +1975,7 @@ _juvy_write_shell_integration_block() {
   cat >> "$rc_file" << EOF
 $_JUVY_SHELL_INTEGRATION_START
 export PATH="\$HOME/.juvy:\$PATH"
-if [[ "\${JUVY_AUTO_BACKUP:-1}" != "0" ]] && [[ -o interactive ]] && command -v juvy >/dev/null 2>&1; then
+if [[ "\${JUVY_AUTO_BACKUP:-1}" != "0" ]] && [[ "\$-" == *i* ]] && command -v juvy >/dev/null 2>&1; then
   if [[ -z "\${JUVY_AUTO_BACKUP_STARTED:-}" ]]; then
     export JUVY_AUTO_BACKUP_STARTED=1
     juvy backup >/dev/null 2>&1 &

--- a/juvy.sh
+++ b/juvy.sh
@@ -1967,30 +1967,6 @@ _juvy_remove_managed_block_from_file() {
   return 1
 }
 
-_juvy_remove_legacy_integration_lines_from_file() {
-  local file_path="$1"
-  local temp_file
-
-  [[ -f "$file_path" ]] || return 0
-
-  temp_file="$file_path.tmp"
-  awk '
-    $0 == "# juvy dotfile backup tool" { next }
-    $0 == "export PATH=\"$HOME/.juvy:$PATH\"" { next }
-    $0 ~ /^[[:space:]]*\([[:space:]]*juvy backup >\/dev\/null 2>&1 &[[:space:]]*\)[[:space:]]*$/ { next }
-    $0 ~ /^[[:space:]]*juvy backup >\/dev\/null 2>&1 &[[:space:]]*$/ { next }
-    { print }
-  ' "$file_path" > "$temp_file"
-
-  if ! cmp -s "$file_path" "$temp_file" 2>/dev/null; then
-    mv "$temp_file" "$file_path"
-    return 0
-  fi
-
-  rm -f "$temp_file"
-  return 1
-}
-
 _juvy_write_shell_integration_block() {
   local rc_file="$1"
 
@@ -2071,7 +2047,6 @@ _juvy_upsert_shell_integration() {
   touch "$rc_file" 2>/dev/null || return 1
 
   _juvy_remove_managed_block_from_file "$rc_file" "$_JUVY_SHELL_INTEGRATION_START" "$_JUVY_SHELL_INTEGRATION_END" >/dev/null 2>&1 || true
-  _juvy_remove_legacy_integration_lines_from_file "$rc_file" >/dev/null 2>&1 || true
 
   if [[ -s "$rc_file" ]]; then
     printf '\n' >> "$rc_file"
@@ -2080,7 +2055,6 @@ _juvy_upsert_shell_integration() {
   _juvy_write_shell_integration_block "$rc_file"
 
   if [[ "$shell_name" == "bash" ]]; then
-    _juvy_remove_legacy_integration_lines_from_file "$HOME/.bash_profile" >/dev/null 2>&1 || true
     _juvy_ensure_bash_profile_bridge || return 1
   fi
 
@@ -2135,9 +2109,6 @@ _juvy_uninstall_internal() {
   for rc_file in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.bash_profile" "$HOME/.profile"; do
     if _juvy_remove_managed_block_from_file "$rc_file" "$_JUVY_SHELL_INTEGRATION_START" "$_JUVY_SHELL_INTEGRATION_END"; then
       echo "Removed juvy from $rc_file"
-    fi
-    if _juvy_remove_legacy_integration_lines_from_file "$rc_file"; then
-      echo "Removed legacy juvy lines from $rc_file"
     fi
   done
   _juvy_remove_bash_profile_bridge

--- a/juvy.sh
+++ b/juvy.sh
@@ -25,6 +25,8 @@ _JUVY_REMOTE_URL=""
 _JUVY_REMOTE_AUTO_SYNC=""
 _JUVY_REMOTE_NAME=""
 _JUVY_PLATFORM=""
+_JUVY_SHELL_INTEGRATION_START="# >>> juvy auto backup >>>"
+_JUVY_SHELL_INTEGRATION_END="# <<< juvy auto backup <<<"
 
 # Global arrays for backup entry collection (Bash 3.2 compatible)
 _JUVY_INCLUDE_PATHS=()
@@ -1145,25 +1147,15 @@ _juvy_doctor() {
     fi
 
     if [[ -f "$juvy_script" ]]; then
-      # Detect shell rc file
-      local rc_file
-      rc_file="$(_juvy_detect_rc_file)"
+      local current_shell
+      current_shell="$(_juvy_detect_shell_name)"
 
-      if [[ ! -f "$rc_file" ]]; then
-        if touch "$rc_file" >/dev/null 2>&1; then
-          _juvy_result "Created $rc_file"
-          (( ++fixes ))
-        fi
-      fi
-
-      if [[ -f "$rc_file" ]] && ! grep -q '\.juvy' "$rc_file"; then
-        {
-          echo ""
-          echo "# juvy dotfile backup tool"
-          echo 'export PATH="$HOME/.juvy:$PATH"'
-        } >> "$rc_file"
-        _juvy_result "Added juvy to PATH in $rc_file"
+      if _juvy_upsert_shell_integration "$current_shell"; then
+        _juvy_result "Repaired shell integration for $current_shell"
         (( ++fixes ))
+      elif [[ "$current_shell" != "zsh" && "$current_shell" != "bash" ]]; then
+        _juvy_warn "Automatic shell integration fix supports bash/zsh only"
+        (( ++warnings ))
       fi
     fi
 
@@ -1172,13 +1164,16 @@ _juvy_doctor() {
     fi
   fi
 
-  # Prerequisites - check for bash or zsh
-  local current_shell="${SHELL##*/}"
-  if [[ "$current_shell" != "bash" && "$current_shell" != "zsh" ]]; then
-    _juvy_error "Shell is not bash or zsh: $SHELL"
-    (( ++issues ))
+  # Prerequisites
+  local current_shell
+  current_shell="$(_juvy_detect_shell_name)"
+  _juvy_info "Current shell: $current_shell"
+
+  if command -v bash >/dev/null 2>&1; then
+    _juvy_result "bash available"
   else
-    _juvy_info "Shell: $current_shell"
+    _juvy_error "Missing dependency: bash"
+    (( ++issues ))
   fi
 
   if command -v rsync >/dev/null 2>&1; then
@@ -1318,11 +1313,26 @@ _juvy_doctor() {
 
   # Shell integration
   local rc_file
-  rc_file="$(_juvy_detect_rc_file)"
-  if [[ -f "$rc_file" ]] && grep -q '\.juvy' "$rc_file"; then
-    _juvy_result "$rc_file adds juvy to PATH"
+  rc_file="$(_juvy_detect_rc_file "$current_shell")"
+  if [[ "$current_shell" == "zsh" || "$current_shell" == "bash" ]]; then
+    if [[ -f "$rc_file" ]] && grep -Fq "$_JUVY_SHELL_INTEGRATION_START" "$rc_file" && grep -Fq "$_JUVY_SHELL_INTEGRATION_END" "$rc_file"; then
+      _juvy_result "Shell integration configured in $rc_file"
+    else
+      _juvy_warn "Shell integration missing in $rc_file (run install.sh or 'juvy doctor --fix')"
+      (( ++warnings ))
+    fi
+
+    if [[ "$current_shell" == "bash" ]]; then
+      local bash_profile="$HOME/.bash_profile"
+      if [[ -f "$bash_profile" ]] && grep -Fq "# >>> juvy bashrc bridge >>>" "$bash_profile" && grep -Fq "# <<< juvy bashrc bridge <<<" "$bash_profile"; then
+        _juvy_result "Bash login shell bridge configured in $bash_profile"
+      else
+        _juvy_warn "Bash login shell bridge missing in $bash_profile (run install.sh or 'juvy doctor --fix')"
+        (( ++warnings ))
+      fi
+    fi
   else
-    _juvy_warn "$rc_file does not add juvy to PATH (run install.sh)"
+    _juvy_warn "Auto shell integration is validated for bash/zsh only"
     (( ++warnings ))
   fi
 
@@ -1339,23 +1349,6 @@ _juvy_doctor() {
   _juvy_warn "Doctor found $warnings warning(s)"
   return 0
 }
-
-# Detect the appropriate shell rc file
-_juvy_detect_rc_file() {
-  local current_shell="${SHELL##*/}"
-  case "$current_shell" in
-    zsh)  echo "$HOME/.zshrc" ;;
-    bash)
-      if [[ -f "$HOME/.bash_profile" ]]; then
-        echo "$HOME/.bash_profile"
-      else
-        echo "$HOME/.bashrc"
-      fi
-      ;;
-    *)    echo "$HOME/.profile" ;;
-  esac
-}
-
 
 _juvy_parse_backup_entry() {
   local entry="$1"
@@ -1925,6 +1918,175 @@ _juvy_update() {
   fi
 }
 
+_juvy_detect_shell_name() {
+  local current_shell="${SHELL##*/}"
+  if [[ -n "$current_shell" ]]; then
+    echo "$current_shell"
+  else
+    echo "unknown"
+  fi
+}
+
+_juvy_detect_rc_file() {
+  local shell_name="${1:-$(_juvy_detect_shell_name)}"
+
+  case "$shell_name" in
+    zsh)
+      echo "$HOME/.zshrc"
+      ;;
+    bash)
+      echo "$HOME/.bashrc"
+      ;;
+    *)
+      echo "$HOME/.profile"
+      ;;
+  esac
+}
+
+_juvy_remove_managed_block_from_file() {
+  local file_path="$1"
+  local start_marker="$2"
+  local end_marker="$3"
+  local temp_file
+
+  [[ -f "$file_path" ]] || return 0
+
+  temp_file="$file_path.tmp"
+  awk -v start="$start_marker" -v end="$end_marker" '
+    $0 == start { in_block=1; removed=1; next }
+    in_block && $0 == end { in_block=0; next }
+    !in_block { print }
+  ' "$file_path" > "$temp_file"
+
+  if ! cmp -s "$file_path" "$temp_file" 2>/dev/null; then
+    mv "$temp_file" "$file_path"
+    return 0
+  fi
+
+  rm -f "$temp_file"
+  return 1
+}
+
+_juvy_remove_legacy_integration_lines_from_file() {
+  local file_path="$1"
+  local temp_file
+
+  [[ -f "$file_path" ]] || return 0
+
+  temp_file="$file_path.tmp"
+  awk '
+    $0 == "# juvy dotfile backup tool" { next }
+    $0 == "export PATH=\"$HOME/.juvy:$PATH\"" { next }
+    $0 ~ /^[[:space:]]*\([[:space:]]*juvy backup >\/dev\/null 2>&1 &[[:space:]]*\)[[:space:]]*$/ { next }
+    $0 ~ /^[[:space:]]*juvy backup >\/dev\/null 2>&1 &[[:space:]]*$/ { next }
+    { print }
+  ' "$file_path" > "$temp_file"
+
+  if ! cmp -s "$file_path" "$temp_file" 2>/dev/null; then
+    mv "$temp_file" "$file_path"
+    return 0
+  fi
+
+  rm -f "$temp_file"
+  return 1
+}
+
+_juvy_write_shell_integration_block() {
+  local rc_file="$1"
+
+  cat >> "$rc_file" << EOF
+$_JUVY_SHELL_INTEGRATION_START
+export PATH="\$HOME/.juvy:\$PATH"
+if [[ "\${JUVY_AUTO_BACKUP:-1}" != "0" ]] && [[ -o interactive ]] && command -v juvy >/dev/null 2>&1; then
+  if [[ -z "\${JUVY_AUTO_BACKUP_STARTED:-}" ]]; then
+    export JUVY_AUTO_BACKUP_STARTED=1
+    _juvy_auto_backup_interval="\${JUVY_AUTO_BACKUP_INTERVAL:-300}"
+    _juvy_auto_backup_stamp="\${XDG_STATE_HOME:-\$HOME/.local/state}/juvy/auto-backup.last"
+    if [[ "\$_juvy_auto_backup_interval" =~ ^[0-9]+$ ]] && (( _juvy_auto_backup_interval > 0 )); then
+      _juvy_auto_backup_now="\$(date +%s 2>/dev/null || echo 0)"
+      _juvy_auto_backup_prev=0
+      if [[ -f "\$_juvy_auto_backup_stamp" ]]; then
+        _juvy_auto_backup_prev="\$(cat "\$_juvy_auto_backup_stamp" 2>/dev/null || echo 0)"
+      fi
+      if (( _juvy_auto_backup_now - _juvy_auto_backup_prev >= _juvy_auto_backup_interval )); then
+        mkdir -p "\$(dirname "\$_juvy_auto_backup_stamp")" >/dev/null 2>&1
+        echo "\$_juvy_auto_backup_now" > "\$_juvy_auto_backup_stamp" 2>/dev/null
+        juvy backup >/dev/null 2>&1 &
+      fi
+    else
+      juvy backup >/dev/null 2>&1 &
+    fi
+    unset _juvy_auto_backup_interval _juvy_auto_backup_stamp _juvy_auto_backup_now _juvy_auto_backup_prev
+  fi
+fi
+$_JUVY_SHELL_INTEGRATION_END
+EOF
+}
+
+_juvy_ensure_bash_profile_bridge() {
+  local bash_profile="$HOME/.bash_profile"
+  local bridge_start="# >>> juvy bashrc bridge >>>"
+  local bridge_end="# <<< juvy bashrc bridge <<<"
+
+  touch "$bash_profile" 2>/dev/null || return 1
+
+  _juvy_remove_managed_block_from_file "$bash_profile" "$bridge_start" "$bridge_end" >/dev/null 2>&1 || true
+
+  if [[ -s "$bash_profile" ]]; then
+    printf '\n' >> "$bash_profile"
+  fi
+
+  cat >> "$bash_profile" << 'EOF'
+# >>> juvy bashrc bridge >>>
+if [ -f "$HOME/.bashrc" ]; then
+  . "$HOME/.bashrc"
+fi
+# <<< juvy bashrc bridge <<<
+EOF
+
+  return 0
+}
+
+_juvy_remove_bash_profile_bridge() {
+  local bash_profile="$HOME/.bash_profile"
+  local bridge_start="# >>> juvy bashrc bridge >>>"
+  local bridge_end="# <<< juvy bashrc bridge <<<"
+
+  _juvy_remove_managed_block_from_file "$bash_profile" "$bridge_start" "$bridge_end" >/dev/null 2>&1 || true
+}
+
+_juvy_upsert_shell_integration() {
+  local shell_name="${1:-$(_juvy_detect_shell_name)}"
+  local rc_file
+
+  case "$shell_name" in
+    zsh|bash)
+      rc_file="$(_juvy_detect_rc_file "$shell_name")"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+
+  touch "$rc_file" 2>/dev/null || return 1
+
+  _juvy_remove_managed_block_from_file "$rc_file" "$_JUVY_SHELL_INTEGRATION_START" "$_JUVY_SHELL_INTEGRATION_END" >/dev/null 2>&1 || true
+  _juvy_remove_legacy_integration_lines_from_file "$rc_file" >/dev/null 2>&1 || true
+
+  if [[ -s "$rc_file" ]]; then
+    printf '\n' >> "$rc_file"
+  fi
+
+  _juvy_write_shell_integration_block "$rc_file"
+
+  if [[ "$shell_name" == "bash" ]]; then
+    _juvy_remove_legacy_integration_lines_from_file "$HOME/.bash_profile" >/dev/null 2>&1 || true
+    _juvy_ensure_bash_profile_bridge || return 1
+  fi
+
+  return 0
+}
+
 _juvy_nuke() {
   local confirm
 
@@ -1970,15 +2132,15 @@ _juvy_uninstall_internal() {
 
   # Remove from shell rc files
   local rc_file
-  for rc_file in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.bash_profile"; do
-    if [[ -f "$rc_file" ]] && grep -q '\.juvy\|juvy backup' "$rc_file"; then
-      # Create a temporary file without the juvy lines
-      {
-        grep -v '\.juvy' "$rc_file" | grep -v "# juvy dotfile backup tool" | grep -v "juvy backup"
-      } > "$rc_file.tmp" && mv "$rc_file.tmp" "$rc_file"
+  for rc_file in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.bash_profile" "$HOME/.profile"; do
+    if _juvy_remove_managed_block_from_file "$rc_file" "$_JUVY_SHELL_INTEGRATION_START" "$_JUVY_SHELL_INTEGRATION_END"; then
       echo "Removed juvy from $rc_file"
     fi
+    if _juvy_remove_legacy_integration_lines_from_file "$rc_file"; then
+      echo "Removed legacy juvy lines from $rc_file"
+    fi
   done
+  _juvy_remove_bash_profile_bridge
 }
 
 _juvy_is_sensitive_file() {

--- a/juvy.sh
+++ b/juvy.sh
@@ -1976,23 +1976,7 @@ export PATH="\$HOME/.juvy:\$PATH"
 if [[ "\${JUVY_AUTO_BACKUP:-1}" != "0" ]] && [[ -o interactive ]] && command -v juvy >/dev/null 2>&1; then
   if [[ -z "\${JUVY_AUTO_BACKUP_STARTED:-}" ]]; then
     export JUVY_AUTO_BACKUP_STARTED=1
-    _juvy_auto_backup_interval="\${JUVY_AUTO_BACKUP_INTERVAL:-300}"
-    _juvy_auto_backup_stamp="\${XDG_STATE_HOME:-\$HOME/.local/state}/juvy/auto-backup.last"
-    if [[ "\$_juvy_auto_backup_interval" =~ ^[0-9]+$ ]] && (( _juvy_auto_backup_interval > 0 )); then
-      _juvy_auto_backup_now="\$(date +%s 2>/dev/null || echo 0)"
-      _juvy_auto_backup_prev=0
-      if [[ -f "\$_juvy_auto_backup_stamp" ]]; then
-        _juvy_auto_backup_prev="\$(cat "\$_juvy_auto_backup_stamp" 2>/dev/null || echo 0)"
-      fi
-      if (( _juvy_auto_backup_now - _juvy_auto_backup_prev >= _juvy_auto_backup_interval )); then
-        mkdir -p "\$(dirname "\$_juvy_auto_backup_stamp")" >/dev/null 2>&1
-        echo "\$_juvy_auto_backup_now" > "\$_juvy_auto_backup_stamp" 2>/dev/null
-        juvy backup >/dev/null 2>&1 &
-      fi
-    else
-      juvy backup >/dev/null 2>&1 &
-    fi
-    unset _juvy_auto_backup_interval _juvy_auto_backup_stamp _juvy_auto_backup_now _juvy_auto_backup_prev
+    juvy backup >/dev/null 2>&1 &
   fi
 fi
 $_JUVY_SHELL_INTEGRATION_END

--- a/src/00_header.sh
+++ b/src/00_header.sh
@@ -25,6 +25,8 @@ _JUVY_REMOTE_URL=""
 _JUVY_REMOTE_AUTO_SYNC=""
 _JUVY_REMOTE_NAME=""
 _JUVY_PLATFORM=""
+_JUVY_SHELL_INTEGRATION_START="# >>> juvy auto backup >>>"
+_JUVY_SHELL_INTEGRATION_END="# <<< juvy auto backup <<<"
 
 # Global arrays for backup entry collection (Bash 3.2 compatible)
 _JUVY_INCLUDE_PATHS=()

--- a/src/30_backup.sh
+++ b/src/30_backup.sh
@@ -151,25 +151,15 @@ _juvy_doctor() {
     fi
 
     if [[ -f "$juvy_script" ]]; then
-      # Detect shell rc file
-      local rc_file
-      rc_file="$(_juvy_detect_rc_file)"
+      local current_shell
+      current_shell="$(_juvy_detect_shell_name)"
 
-      if [[ ! -f "$rc_file" ]]; then
-        if touch "$rc_file" >/dev/null 2>&1; then
-          _juvy_result "Created $rc_file"
-          (( ++fixes ))
-        fi
-      fi
-
-      if [[ -f "$rc_file" ]] && ! grep -q '\.juvy' "$rc_file"; then
-        {
-          echo ""
-          echo "# juvy dotfile backup tool"
-          echo 'export PATH="$HOME/.juvy:$PATH"'
-        } >> "$rc_file"
-        _juvy_result "Added juvy to PATH in $rc_file"
+      if _juvy_upsert_shell_integration "$current_shell"; then
+        _juvy_result "Repaired shell integration for $current_shell"
         (( ++fixes ))
+      elif [[ "$current_shell" != "zsh" && "$current_shell" != "bash" ]]; then
+        _juvy_warn "Automatic shell integration fix supports bash/zsh only"
+        (( ++warnings ))
       fi
     fi
 
@@ -178,13 +168,16 @@ _juvy_doctor() {
     fi
   fi
 
-  # Prerequisites - check for bash or zsh
-  local current_shell="${SHELL##*/}"
-  if [[ "$current_shell" != "bash" && "$current_shell" != "zsh" ]]; then
-    _juvy_error "Shell is not bash or zsh: $SHELL"
-    (( ++issues ))
+  # Prerequisites
+  local current_shell
+  current_shell="$(_juvy_detect_shell_name)"
+  _juvy_info "Current shell: $current_shell"
+
+  if command -v bash >/dev/null 2>&1; then
+    _juvy_result "bash available"
   else
-    _juvy_info "Shell: $current_shell"
+    _juvy_error "Missing dependency: bash"
+    (( ++issues ))
   fi
 
   if command -v rsync >/dev/null 2>&1; then
@@ -324,11 +317,26 @@ _juvy_doctor() {
 
   # Shell integration
   local rc_file
-  rc_file="$(_juvy_detect_rc_file)"
-  if [[ -f "$rc_file" ]] && grep -q '\.juvy' "$rc_file"; then
-    _juvy_result "$rc_file adds juvy to PATH"
+  rc_file="$(_juvy_detect_rc_file "$current_shell")"
+  if [[ "$current_shell" == "zsh" || "$current_shell" == "bash" ]]; then
+    if [[ -f "$rc_file" ]] && grep -Fq "$_JUVY_SHELL_INTEGRATION_START" "$rc_file" && grep -Fq "$_JUVY_SHELL_INTEGRATION_END" "$rc_file"; then
+      _juvy_result "Shell integration configured in $rc_file"
+    else
+      _juvy_warn "Shell integration missing in $rc_file (run install.sh or 'juvy doctor --fix')"
+      (( ++warnings ))
+    fi
+
+    if [[ "$current_shell" == "bash" ]]; then
+      local bash_profile="$HOME/.bash_profile"
+      if [[ -f "$bash_profile" ]] && grep -Fq "# >>> juvy bashrc bridge >>>" "$bash_profile" && grep -Fq "# <<< juvy bashrc bridge <<<" "$bash_profile"; then
+        _juvy_result "Bash login shell bridge configured in $bash_profile"
+      else
+        _juvy_warn "Bash login shell bridge missing in $bash_profile (run install.sh or 'juvy doctor --fix')"
+        (( ++warnings ))
+      fi
+    fi
   else
-    _juvy_warn "$rc_file does not add juvy to PATH (run install.sh)"
+    _juvy_warn "Auto shell integration is validated for bash/zsh only"
     (( ++warnings ))
   fi
 
@@ -345,23 +353,6 @@ _juvy_doctor() {
   _juvy_warn "Doctor found $warnings warning(s)"
   return 0
 }
-
-# Detect the appropriate shell rc file
-_juvy_detect_rc_file() {
-  local current_shell="${SHELL##*/}"
-  case "$current_shell" in
-    zsh)  echo "$HOME/.zshrc" ;;
-    bash)
-      if [[ -f "$HOME/.bash_profile" ]]; then
-        echo "$HOME/.bash_profile"
-      else
-        echo "$HOME/.bashrc"
-      fi
-      ;;
-    *)    echo "$HOME/.profile" ;;
-  esac
-}
-
 
 _juvy_parse_backup_entry() {
   local entry="$1"

--- a/src/40_utils.sh
+++ b/src/40_utils.sh
@@ -575,30 +575,6 @@ _juvy_remove_managed_block_from_file() {
   return 1
 }
 
-_juvy_remove_legacy_integration_lines_from_file() {
-  local file_path="$1"
-  local temp_file
-
-  [[ -f "$file_path" ]] || return 0
-
-  temp_file="$file_path.tmp"
-  awk '
-    $0 == "# juvy dotfile backup tool" { next }
-    $0 == "export PATH=\"$HOME/.juvy:$PATH\"" { next }
-    $0 ~ /^[[:space:]]*\([[:space:]]*juvy backup >\/dev\/null 2>&1 &[[:space:]]*\)[[:space:]]*$/ { next }
-    $0 ~ /^[[:space:]]*juvy backup >\/dev\/null 2>&1 &[[:space:]]*$/ { next }
-    { print }
-  ' "$file_path" > "$temp_file"
-
-  if ! cmp -s "$file_path" "$temp_file" 2>/dev/null; then
-    mv "$temp_file" "$file_path"
-    return 0
-  fi
-
-  rm -f "$temp_file"
-  return 1
-}
-
 _juvy_write_shell_integration_block() {
   local rc_file="$1"
 
@@ -679,7 +655,6 @@ _juvy_upsert_shell_integration() {
   touch "$rc_file" 2>/dev/null || return 1
 
   _juvy_remove_managed_block_from_file "$rc_file" "$_JUVY_SHELL_INTEGRATION_START" "$_JUVY_SHELL_INTEGRATION_END" >/dev/null 2>&1 || true
-  _juvy_remove_legacy_integration_lines_from_file "$rc_file" >/dev/null 2>&1 || true
 
   if [[ -s "$rc_file" ]]; then
     printf '\n' >> "$rc_file"
@@ -688,7 +663,6 @@ _juvy_upsert_shell_integration() {
   _juvy_write_shell_integration_block "$rc_file"
 
   if [[ "$shell_name" == "bash" ]]; then
-    _juvy_remove_legacy_integration_lines_from_file "$HOME/.bash_profile" >/dev/null 2>&1 || true
     _juvy_ensure_bash_profile_bridge || return 1
   fi
 
@@ -743,9 +717,6 @@ _juvy_uninstall_internal() {
   for rc_file in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.bash_profile" "$HOME/.profile"; do
     if _juvy_remove_managed_block_from_file "$rc_file" "$_JUVY_SHELL_INTEGRATION_START" "$_JUVY_SHELL_INTEGRATION_END"; then
       echo "Removed juvy from $rc_file"
-    fi
-    if _juvy_remove_legacy_integration_lines_from_file "$rc_file"; then
-      echo "Removed legacy juvy lines from $rc_file"
     fi
   done
   _juvy_remove_bash_profile_bridge

--- a/src/40_utils.sh
+++ b/src/40_utils.sh
@@ -558,6 +558,8 @@ _juvy_remove_managed_block_from_file() {
   local temp_file
 
   [[ -f "$file_path" ]] || return 0
+  grep -Fq "$start_marker" "$file_path" || return 1
+  grep -Fq "$end_marker" "$file_path" || return 1
 
   temp_file="$file_path.tmp"
   awk -v start="$start_marker" -v end="$end_marker" '
@@ -581,7 +583,7 @@ _juvy_write_shell_integration_block() {
   cat >> "$rc_file" << EOF
 $_JUVY_SHELL_INTEGRATION_START
 export PATH="\$HOME/.juvy:\$PATH"
-if [[ "\${JUVY_AUTO_BACKUP:-1}" != "0" ]] && [[ -o interactive ]] && command -v juvy >/dev/null 2>&1; then
+if [[ "\${JUVY_AUTO_BACKUP:-1}" != "0" ]] && [[ "\$-" == *i* ]] && command -v juvy >/dev/null 2>&1; then
   if [[ -z "\${JUVY_AUTO_BACKUP_STARTED:-}" ]]; then
     export JUVY_AUTO_BACKUP_STARTED=1
     juvy backup >/dev/null 2>&1 &

--- a/src/40_utils.sh
+++ b/src/40_utils.sh
@@ -584,23 +584,7 @@ export PATH="\$HOME/.juvy:\$PATH"
 if [[ "\${JUVY_AUTO_BACKUP:-1}" != "0" ]] && [[ -o interactive ]] && command -v juvy >/dev/null 2>&1; then
   if [[ -z "\${JUVY_AUTO_BACKUP_STARTED:-}" ]]; then
     export JUVY_AUTO_BACKUP_STARTED=1
-    _juvy_auto_backup_interval="\${JUVY_AUTO_BACKUP_INTERVAL:-300}"
-    _juvy_auto_backup_stamp="\${XDG_STATE_HOME:-\$HOME/.local/state}/juvy/auto-backup.last"
-    if [[ "\$_juvy_auto_backup_interval" =~ ^[0-9]+$ ]] && (( _juvy_auto_backup_interval > 0 )); then
-      _juvy_auto_backup_now="\$(date +%s 2>/dev/null || echo 0)"
-      _juvy_auto_backup_prev=0
-      if [[ -f "\$_juvy_auto_backup_stamp" ]]; then
-        _juvy_auto_backup_prev="\$(cat "\$_juvy_auto_backup_stamp" 2>/dev/null || echo 0)"
-      fi
-      if (( _juvy_auto_backup_now - _juvy_auto_backup_prev >= _juvy_auto_backup_interval )); then
-        mkdir -p "\$(dirname "\$_juvy_auto_backup_stamp")" >/dev/null 2>&1
-        echo "\$_juvy_auto_backup_now" > "\$_juvy_auto_backup_stamp" 2>/dev/null
-        juvy backup >/dev/null 2>&1 &
-      fi
-    else
-      juvy backup >/dev/null 2>&1 &
-    fi
-    unset _juvy_auto_backup_interval _juvy_auto_backup_stamp _juvy_auto_backup_now _juvy_auto_backup_prev
+    juvy backup >/dev/null 2>&1 &
   fi
 fi
 $_JUVY_SHELL_INTEGRATION_END

--- a/src/40_utils.sh
+++ b/src/40_utils.sh
@@ -526,6 +526,175 @@ _juvy_update() {
   fi
 }
 
+_juvy_detect_shell_name() {
+  local current_shell="${SHELL##*/}"
+  if [[ -n "$current_shell" ]]; then
+    echo "$current_shell"
+  else
+    echo "unknown"
+  fi
+}
+
+_juvy_detect_rc_file() {
+  local shell_name="${1:-$(_juvy_detect_shell_name)}"
+
+  case "$shell_name" in
+    zsh)
+      echo "$HOME/.zshrc"
+      ;;
+    bash)
+      echo "$HOME/.bashrc"
+      ;;
+    *)
+      echo "$HOME/.profile"
+      ;;
+  esac
+}
+
+_juvy_remove_managed_block_from_file() {
+  local file_path="$1"
+  local start_marker="$2"
+  local end_marker="$3"
+  local temp_file
+
+  [[ -f "$file_path" ]] || return 0
+
+  temp_file="$file_path.tmp"
+  awk -v start="$start_marker" -v end="$end_marker" '
+    $0 == start { in_block=1; removed=1; next }
+    in_block && $0 == end { in_block=0; next }
+    !in_block { print }
+  ' "$file_path" > "$temp_file"
+
+  if ! cmp -s "$file_path" "$temp_file" 2>/dev/null; then
+    mv "$temp_file" "$file_path"
+    return 0
+  fi
+
+  rm -f "$temp_file"
+  return 1
+}
+
+_juvy_remove_legacy_integration_lines_from_file() {
+  local file_path="$1"
+  local temp_file
+
+  [[ -f "$file_path" ]] || return 0
+
+  temp_file="$file_path.tmp"
+  awk '
+    $0 == "# juvy dotfile backup tool" { next }
+    $0 == "export PATH=\"$HOME/.juvy:$PATH\"" { next }
+    $0 ~ /^[[:space:]]*\([[:space:]]*juvy backup >\/dev\/null 2>&1 &[[:space:]]*\)[[:space:]]*$/ { next }
+    $0 ~ /^[[:space:]]*juvy backup >\/dev\/null 2>&1 &[[:space:]]*$/ { next }
+    { print }
+  ' "$file_path" > "$temp_file"
+
+  if ! cmp -s "$file_path" "$temp_file" 2>/dev/null; then
+    mv "$temp_file" "$file_path"
+    return 0
+  fi
+
+  rm -f "$temp_file"
+  return 1
+}
+
+_juvy_write_shell_integration_block() {
+  local rc_file="$1"
+
+  cat >> "$rc_file" << EOF
+$_JUVY_SHELL_INTEGRATION_START
+export PATH="\$HOME/.juvy:\$PATH"
+if [[ "\${JUVY_AUTO_BACKUP:-1}" != "0" ]] && [[ -o interactive ]] && command -v juvy >/dev/null 2>&1; then
+  if [[ -z "\${JUVY_AUTO_BACKUP_STARTED:-}" ]]; then
+    export JUVY_AUTO_BACKUP_STARTED=1
+    _juvy_auto_backup_interval="\${JUVY_AUTO_BACKUP_INTERVAL:-300}"
+    _juvy_auto_backup_stamp="\${XDG_STATE_HOME:-\$HOME/.local/state}/juvy/auto-backup.last"
+    if [[ "\$_juvy_auto_backup_interval" =~ ^[0-9]+$ ]] && (( _juvy_auto_backup_interval > 0 )); then
+      _juvy_auto_backup_now="\$(date +%s 2>/dev/null || echo 0)"
+      _juvy_auto_backup_prev=0
+      if [[ -f "\$_juvy_auto_backup_stamp" ]]; then
+        _juvy_auto_backup_prev="\$(cat "\$_juvy_auto_backup_stamp" 2>/dev/null || echo 0)"
+      fi
+      if (( _juvy_auto_backup_now - _juvy_auto_backup_prev >= _juvy_auto_backup_interval )); then
+        mkdir -p "\$(dirname "\$_juvy_auto_backup_stamp")" >/dev/null 2>&1
+        echo "\$_juvy_auto_backup_now" > "\$_juvy_auto_backup_stamp" 2>/dev/null
+        juvy backup >/dev/null 2>&1 &
+      fi
+    else
+      juvy backup >/dev/null 2>&1 &
+    fi
+    unset _juvy_auto_backup_interval _juvy_auto_backup_stamp _juvy_auto_backup_now _juvy_auto_backup_prev
+  fi
+fi
+$_JUVY_SHELL_INTEGRATION_END
+EOF
+}
+
+_juvy_ensure_bash_profile_bridge() {
+  local bash_profile="$HOME/.bash_profile"
+  local bridge_start="# >>> juvy bashrc bridge >>>"
+  local bridge_end="# <<< juvy bashrc bridge <<<"
+
+  touch "$bash_profile" 2>/dev/null || return 1
+
+  _juvy_remove_managed_block_from_file "$bash_profile" "$bridge_start" "$bridge_end" >/dev/null 2>&1 || true
+
+  if [[ -s "$bash_profile" ]]; then
+    printf '\n' >> "$bash_profile"
+  fi
+
+  cat >> "$bash_profile" << 'EOF'
+# >>> juvy bashrc bridge >>>
+if [ -f "$HOME/.bashrc" ]; then
+  . "$HOME/.bashrc"
+fi
+# <<< juvy bashrc bridge <<<
+EOF
+
+  return 0
+}
+
+_juvy_remove_bash_profile_bridge() {
+  local bash_profile="$HOME/.bash_profile"
+  local bridge_start="# >>> juvy bashrc bridge >>>"
+  local bridge_end="# <<< juvy bashrc bridge <<<"
+
+  _juvy_remove_managed_block_from_file "$bash_profile" "$bridge_start" "$bridge_end" >/dev/null 2>&1 || true
+}
+
+_juvy_upsert_shell_integration() {
+  local shell_name="${1:-$(_juvy_detect_shell_name)}"
+  local rc_file
+
+  case "$shell_name" in
+    zsh|bash)
+      rc_file="$(_juvy_detect_rc_file "$shell_name")"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+
+  touch "$rc_file" 2>/dev/null || return 1
+
+  _juvy_remove_managed_block_from_file "$rc_file" "$_JUVY_SHELL_INTEGRATION_START" "$_JUVY_SHELL_INTEGRATION_END" >/dev/null 2>&1 || true
+  _juvy_remove_legacy_integration_lines_from_file "$rc_file" >/dev/null 2>&1 || true
+
+  if [[ -s "$rc_file" ]]; then
+    printf '\n' >> "$rc_file"
+  fi
+
+  _juvy_write_shell_integration_block "$rc_file"
+
+  if [[ "$shell_name" == "bash" ]]; then
+    _juvy_remove_legacy_integration_lines_from_file "$HOME/.bash_profile" >/dev/null 2>&1 || true
+    _juvy_ensure_bash_profile_bridge || return 1
+  fi
+
+  return 0
+}
+
 _juvy_nuke() {
   local confirm
 
@@ -571,15 +740,15 @@ _juvy_uninstall_internal() {
 
   # Remove from shell rc files
   local rc_file
-  for rc_file in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.bash_profile"; do
-    if [[ -f "$rc_file" ]] && grep -q '\.juvy\|juvy backup' "$rc_file"; then
-      # Create a temporary file without the juvy lines
-      {
-        grep -v '\.juvy' "$rc_file" | grep -v "# juvy dotfile backup tool" | grep -v "juvy backup"
-      } > "$rc_file.tmp" && mv "$rc_file.tmp" "$rc_file"
+  for rc_file in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.bash_profile" "$HOME/.profile"; do
+    if _juvy_remove_managed_block_from_file "$rc_file" "$_JUVY_SHELL_INTEGRATION_START" "$_JUVY_SHELL_INTEGRATION_END"; then
       echo "Removed juvy from $rc_file"
     fi
+    if _juvy_remove_legacy_integration_lines_from_file "$rc_file"; then
+      echo "Removed legacy juvy lines from $rc_file"
+    fi
   done
+  _juvy_remove_bash_profile_bridge
 }
 
 _juvy_is_sensitive_file() {

--- a/tests/bats/doctor.bats
+++ b/tests/bats/doctor.bats
@@ -92,24 +92,20 @@ teardown() {
   [ "$status" -eq 0 ]
 }
 
-@test "doctor --fix writes managed zsh shell integration and removes legacy lines" {
+@test "doctor --fix writes managed zsh shell integration" {
   export SHELL="/bin/zsh"
 
   mkdir -p "$HOME/.juvy"
   touch "$HOME/.juvy/juvy"
 
-  cat > "$HOME/.zshrc" << 'EOF'
-# juvy dotfile backup tool
-export PATH="$HOME/.juvy:$PATH"
-( juvy backup >/dev/null 2>&1 & )
-EOF
+  create_test_file "~/.zshrc" "# existing zshrc content"
 
   run juvy doctor --fix
   [ "$status" -eq 0 ]
 
   assert_file_contains "$HOME/.zshrc" "# >>> juvy auto backup >>>"
   assert_file_contains "$HOME/.zshrc" "# <<< juvy auto backup <<<"
-  assert_file_not_contains "$HOME/.zshrc" "# juvy dotfile backup tool"
+  assert_file_contains "$HOME/.zshrc" "# existing zshrc content"
 }
 
 @test "doctor --fix writes bash integration and bash_profile bridge" {

--- a/tests/bats/doctor.bats
+++ b/tests/bats/doctor.bats
@@ -139,6 +139,22 @@ EOF
   assert_file_not_contains "$HOME/.zshrc" "# <<< juvy auto backup <<<"
 }
 
+@test "uninstall does not truncate rc file when managed block end marker is missing" {
+  cat > "$HOME/.zshrc" << 'EOF'
+export FOO=bar
+# >>> juvy auto backup >>>
+export PATH="$HOME/.juvy:$PATH"
+juvy backup >/dev/null 2>&1 &
+export BAR=baz
+EOF
+
+  _juvy_uninstall_internal
+
+  assert_file_contains "$HOME/.zshrc" "export FOO=bar"
+  assert_file_contains "$HOME/.zshrc" "export BAR=baz"
+  assert_file_contains "$HOME/.zshrc" "# >>> juvy auto backup >>>"
+}
+
 @test "doctor validates exclude patterns" {
   create_test_dir "~/.config/app/"
   create_test_file "~/.config/app/config.txt" "config"

--- a/tests/bats/doctor.bats
+++ b/tests/bats/doctor.bats
@@ -92,6 +92,57 @@ teardown() {
   [ "$status" -eq 0 ]
 }
 
+@test "doctor --fix writes managed zsh shell integration and removes legacy lines" {
+  export SHELL="/bin/zsh"
+
+  mkdir -p "$HOME/.juvy"
+  touch "$HOME/.juvy/juvy"
+
+  cat > "$HOME/.zshrc" << 'EOF'
+# juvy dotfile backup tool
+export PATH="$HOME/.juvy:$PATH"
+( juvy backup >/dev/null 2>&1 & )
+EOF
+
+  run juvy doctor --fix
+  [ "$status" -eq 0 ]
+
+  assert_file_contains "$HOME/.zshrc" "# >>> juvy auto backup >>>"
+  assert_file_contains "$HOME/.zshrc" "# <<< juvy auto backup <<<"
+  assert_file_not_contains "$HOME/.zshrc" "# juvy dotfile backup tool"
+}
+
+@test "doctor --fix writes bash integration and bash_profile bridge" {
+  export SHELL="/bin/bash"
+
+  mkdir -p "$HOME/.juvy"
+  touch "$HOME/.juvy/juvy"
+  create_test_file "~/.bashrc" "# existing bashrc content"
+
+  run juvy doctor --fix
+  [ "$status" -eq 0 ]
+
+  assert_file_contains "$HOME/.bashrc" "# >>> juvy auto backup >>>"
+  assert_file_contains "$HOME/.bash_profile" "# >>> juvy bashrc bridge >>>"
+  assert_file_contains "$HOME/.bash_profile" ". \"\$HOME/.bashrc\""
+}
+
+@test "uninstall removes managed integration blocks and keeps unrelated rc lines" {
+  cat > "$HOME/.zshrc" << 'EOF'
+export FOO=bar
+# >>> juvy auto backup >>>
+export PATH="$HOME/.juvy:$PATH"
+juvy backup >/dev/null 2>&1 &
+# <<< juvy auto backup <<<
+EOF
+
+  _juvy_uninstall_internal
+
+  assert_file_contains "$HOME/.zshrc" "export FOO=bar"
+  assert_file_not_contains "$HOME/.zshrc" "# >>> juvy auto backup >>>"
+  assert_file_not_contains "$HOME/.zshrc" "# <<< juvy auto backup <<<"
+}
+
 @test "doctor validates exclude patterns" {
   create_test_dir "~/.config/app/"
   create_test_file "~/.config/app/config.txt" "config"


### PR DESCRIPTION
## Summary
Implements Phase 1 of shell-aware injection improvements from #47.

- Adds managed, idempotent shell-integration blocks for `zsh` and `bash`
- Migrates legacy one-line shell injection
- Adds `bash` login-shell bridge (`~/.bash_profile` -> `~/.bashrc`)
- Updates uninstall/nuke cleanup to remove managed blocks safely
- Updates doctor validation and `doctor --fix` integration repair
- Documents `JUVY_AUTO_BACKUP` and `JUVY_AUTO_BACKUP_INTERVAL`

Closes #47

## Testing
- `./scripts/build.sh`
- `./tests/run-docker-tests.sh doctor.bats`
- `./tests/run-docker-tests.sh`
- `./tests/run-docker-tests.sh --bash32` *(could not run here: `no such service: test-bash32`)*
